### PR TITLE
Update pnpm version to 11.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     name: Test Build
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    container: node:26-alpine@sha256:a2dc166a387cc6ca1e62d0c8e265e49ca985d6e60abc9fe6e6c3d6ce8e63f606
+    container: node:26-alpine@sha256:144769ec3f32e8ee36b3cfde91e82bee25d9367b20f31a151f3f7eea3a2a8541
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
         with:
-          version: 11.6.0
+          version: 11.9.0
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
This pull request updates the version of pnpm used in the GitHub Actions workflow. The workflow now uses a newer version of pnpm to install dependencies.

- **CI/CD Tooling Update:**
  * [`.github/workflows/gh-pages.yml`](diffhunk://#diff-c04119feaeffc2c216f069aec66797f2f839a2074287060698e3a2440dec8d45L25-R25): Upgraded the pnpm version from `11.6.0` to `11.9.0` to ensure the workflow uses the latest features and fixes.